### PR TITLE
Fix typo in component mixin name

### DIFF
--- a/north/north/_components.scss
+++ b/north/north/_components.scss
@@ -8,7 +8,7 @@
 //////////////////////////////
 // Mixins
 //////////////////////////////
-@mixin components($name) {
+@mixin component($name) {
   @include aspects($name) {
     @content;
   }


### PR DESCRIPTION
Should be `component`; was `components`
