### PR TITLE
Restructure using markdown quotation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,15 @@ Benefit statements describe why a feature is important to be built based on [use
 
 #### Requirements
 
-The functional requirements of a user story are based on the desired user experience of a feature and should be thorough enough to be completed by a [designer](#designer) or [developer](#developer) without additional question. An example of incomplete requirements would be "Create a photo gallery". On the other hand, "Create a rotating display that holds five items, paginates with swipe or mouse click, draws in an image from the Image content type displayed at a 16:9 ratio with the title and short description and can resize fluidly, ordered by most recent item" is much more thorough and can be built and designed without further input.
+The functional requirements of a user story are based on the desired user experience of a feature and should be thorough enough to be completed by a [designer](#designer) or [developer](#developer) without additional question. 
+
+An example of incomplete requirements would be:
+
+> Create a photo gallery
+
+On the other hand, the following is much more thorough and can be built and designed without further input:
+
+> Create a rotating display that holds five items, paginates with swipe or mouse click, draws in an image from the Image content type displayed at a 16:9 ratio with the title and short description and can resize fluidly, ordered by most recent item
 
 #### Size and Value
 


### PR DESCRIPTION
The second quoted example is IMO too long to break the sentence up. The only issue might be that the document is currently only using blockquote formatting for quoting external literature or people. I'm open to suggestions on formatting it differently, just think it needs to be broken up for readability.